### PR TITLE
Disable `useDependencyInformation`

### DIFF
--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -1,21 +1,18 @@
 {
-	"modListVersion": 2,
-	"modList": [{
-		"modid": "${modId}",
-		"name": "${modName}",
-		"description": "Define which Blocks can be placed or not, depending on the dimension",
-		"version": "${modVersion}",
-		"mcversion": "${minecraftVersion}",
-		"url": "",
-		"updateUrl": "",
-		"authorList": [
-			"Namikon"
-		],
-		"credits": "",
-		"logoFile": "",
-		"screenshots": [],
-		"requiredMods": ["Forge@[10.13.2.1291,)", "YAMCore@[0.5.65,)"],
-		"dependencies": ["YAMCore@[0.5.65,)"],
-		"useDependencyInformation": true
-	}]
+  "modListVersion": 2,
+  "modList": [{
+    "modid": "${modId}",
+    "name": "${modName}",
+    "description": "Define which Blocks can be placed or not, depending on the dimension",
+    "version": "${modVersion}",
+    "mcversion": "${minecraftVersion}",
+    "url": "",
+    "updateUrl": "",
+    "authorList": [
+      "Namikon"
+    ],
+    "credits": "",
+    "logoFile": "",
+    "screenshots": []
+  }]
 }


### PR DESCRIPTION
`"useDependencyInformation": true` overrides the dependencies declared in the `@Mod` annotation with the dependencies declared in this file.